### PR TITLE
Fixes Length metric calculation.

### DIFF
--- a/Model/Api/Builder/Order.php
+++ b/Model/Api/Builder/Order.php
@@ -414,8 +414,8 @@ class Order
             }
         }
 
-        if ($lengthAttribute = $this->config->getProductAttributeLength() * $k) {
-            if ($length = $product->getData($lengthAttribute)) {
+        if ($lengthAttribute = $this->config->getProductAttributeLength()) {
+            if ($length = $product->getData($lengthAttribute) * $k) {
                 $dimensionArray['length'] = (int)$length;
             }
         }


### PR DESCRIPTION
Fix for the error  - 
There is an error in /var/www/html/vendor/paazl/magento2-checkout-widget/Model/Api/Builder/Order.php at line: 418 Unsupported operand types: int * string#0